### PR TITLE
Compatiblity: ensure compatibility with Jetpack 11.8

### DIFF
--- a/add-fediverse-icons-to-jetpack.php
+++ b/add-fediverse-icons-to-jetpack.php
@@ -7,7 +7,7 @@
  * Author URI:  https://jan.boddez.net/
  * License:     GNU General Public License v3
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
- * Version:     0.4.0
+ * Version:     0.4.1
  *
  * @package Fediverse_Icons_Jetpack
  */

--- a/includes/class-fediverse-icons-jetpack.php
+++ b/includes/class-fediverse-icons-jetpack.php
@@ -88,6 +88,17 @@ class Fediverse_Icons_Jetpack {
 			return $item_output;
 		}
 
+		/*
+		 * If we're running Jetpack 11.8 or higher,
+		 * we do not need to handle the 'mastodon' social icon
+		 * in Jetpack's Social Menu.
+		 * This is now handled by Jetpack itself: https://github.com/Automattic/jetpack/pull/28175
+		 */
+		$jetpack_version = defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '0';
+		if ( version_compare( $jetpack_version, '11.8', '>=' ) ) {
+			unset( static::$social_icons['Mastodon'] );
+		}
+
 		// If the URL in `$item_output` matches any of the sites above, apply
 		// the SVG icon. For this to work, the menu item must be named after the
 		// platform. We can't deduce anything from a domain name, like Jetpack

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,10 @@ This plugin currently provides icons for:
 - Pixelfed
 
 == Changelog ==
+
+= 0.4.1 =
+Ensure compatibility with Jetpack 11.8
+
 = 0.4.0 =
 Add (experimental) support for block themes.
 


### PR DESCRIPTION
Nice plugin! As Jetpack has made some changes in its upcoming version (scheduled to be released next Tuesday), I wanted to reach out and suggest a change to ensure full compatibility between the 2 plugins.

************

In Jetpack 11.8 or higher, the plugin includes Mastodon as a valid Social Menu option. Let's fallback to Jetpack's implementation in this case.

This only fallbacks to Jetpack for the Social Menu logic; it doesnt touch the block theme feature, since that's not supported by Jetpack.

For reference, here is Jetpack's PR:
Automattic/jetpack#28175